### PR TITLE
Health Client

### DIFF
--- a/grpc/gateway/gateway.go
+++ b/grpc/gateway/gateway.go
@@ -133,6 +133,17 @@ func NewGateway(options ...Option) (*http.ServeMux, error) {
 		HeaderConfig: internalmetadata.HeaderConfig{
 			HeadersToForward: internalmetadata.GetHeadersToForward(),
 		},
+
+		// Logger is set to NoOp by default to prevent duplicate logging of requests.
+		// Since the gRPC gateway acts as an HTTP proxy to gRPC services, logging
+		// at both the HTTP layer and gRPC layer would result in redundant log entries
+		// for the same request.
+		//
+		// If logging is desired, use WithLogger option to provide a custom logger:
+		//   gateway.NewGateway(
+		//       gateway.WithLogger(myLogger),
+		//       gateway.WithRequestLogging(),
+		//   )
 		Logger: logger.NoOp(),
 	}
 

--- a/grpc/health/client.go
+++ b/grpc/health/client.go
@@ -1,4 +1,4 @@
-package heakth
+package health
 
 import (
 	"context"

--- a/grpc/health/client.go
+++ b/grpc/health/client.go
@@ -35,43 +35,48 @@ func WithDialOptions(opts ...grpc.DialOption) Option {
 	}
 }
 
-// HealthChecker is a wrapper around the gRPC health client that manages the underlying connection.
-type HealthChecker struct {
+// Checker is a wrapper around the gRPC health client that manages the underlying connection.
+type Checker struct {
 	client grpc_health_v1.HealthClient
 	conn   *grpc.ClientConn
 }
 
+// Client returns the underlying gRPC health client.
+func (c *Checker) Client() grpc_health_v1.HealthClient {
+	return c.client
+}
+
 // Check performs a health check on the specified service.
-func (h *HealthChecker) Check(
+func (c *Checker) Check(
 	ctx context.Context,
 	req *grpc_health_v1.HealthCheckRequest,
 	opts ...grpc.CallOption,
 ) (*grpc_health_v1.HealthCheckResponse, error) {
-	return h.client.Check(ctx, req, opts...)
+	return c.client.Check(ctx, req, opts...)
 }
 
 // Watch watches the health status of the specified service.
-func (h *HealthChecker) Watch(
+func (c *Checker) Watch(
 	ctx context.Context,
 	req *grpc_health_v1.HealthCheckRequest,
 	opts ...grpc.CallOption,
 ) (grpc_health_v1.Health_WatchClient, error) {
-	return h.client.Watch(ctx, req, opts...)
+	return c.client.Watch(ctx, req, opts...)
 }
 
 // Close closes the underlying gRPC connection.
-func (h *HealthChecker) Close() error {
-	if h.conn != nil {
-		return h.conn.Close()
+func (c *Checker) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
 	}
 	return nil
 }
 
-// NewHealthChecker creates a new HealthChecker with the provided functional options.
+// NewHealthChecker creates a new Checker with the provided functional options.
 // It creates the connection and waits for it to be ready if a dial timeout is set.
 // The user should call Close() when done, typically with defer.
 // Default target is "localhost:50051", insecure, and 10s dial timeout.
-func NewHealthChecker(opts ...Option) (*HealthChecker, error) {
+func NewHealthChecker(opts ...Option) (*Checker, error) {
 	c := &config{
 		target:      "localhost:50051",
 		dialTimeout: 10 * time.Second,
@@ -104,5 +109,5 @@ func NewHealthChecker(opts ...Option) (*HealthChecker, error) {
 
 	client := grpc_health_v1.NewHealthClient(conn)
 
-	return &HealthChecker{client: client, conn: conn}, nil
+	return &Checker{client: client, conn: conn}, nil
 }

--- a/grpc/health/client.go
+++ b/grpc/health/client.go
@@ -1,0 +1,108 @@
+package heakth
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// config holds the configuration for creating a health checker.
+type config struct {
+	target      string
+	dialTimeout time.Duration
+	dialOptions []grpc.DialOption
+}
+
+// Option is a functional option for configuring the health checker creation.
+type Option func(*config)
+
+// WithTarget sets the target address for the gRPC connection (e.g., "localhost:50051").
+func WithTarget(target string) Option {
+	return func(c *config) {
+		c.target = target
+	}
+}
+
+// WithDialOptions allows passing custom gRPC DialOptions.
+func WithDialOptions(opts ...grpc.DialOption) Option {
+	return func(c *config) {
+		c.dialOptions = append(c.dialOptions, opts...)
+	}
+}
+
+// HealthChecker is a wrapper around the gRPC health client that manages the underlying connection.
+type HealthChecker struct {
+	client grpc_health_v1.HealthClient
+	conn   *grpc.ClientConn
+}
+
+// Check performs a health check on the specified service.
+func (h *HealthChecker) Check(
+	ctx context.Context,
+	req *grpc_health_v1.HealthCheckRequest,
+	opts ...grpc.CallOption,
+) (*grpc_health_v1.HealthCheckResponse, error) {
+	return h.client.Check(ctx, req, opts...)
+}
+
+// Watch watches the health status of the specified service.
+func (h *HealthChecker) Watch(
+	ctx context.Context,
+	req *grpc_health_v1.HealthCheckRequest,
+	opts ...grpc.CallOption,
+) (grpc_health_v1.Health_WatchClient, error) {
+	return h.client.Watch(ctx, req, opts...)
+}
+
+// Close closes the underlying gRPC connection.
+func (h *HealthChecker) Close() error {
+	if h.conn != nil {
+		return h.conn.Close()
+	}
+	return nil
+}
+
+// NewHealthChecker creates a new HealthChecker with the provided functional options.
+// It creates the connection and waits for it to be ready if a dial timeout is set.
+// The user should call Close() when done, typically with defer.
+// Default target is "localhost:50051", insecure, and 10s dial timeout.
+func NewHealthChecker(opts ...Option) (*HealthChecker, error) {
+	c := &config{
+		target:      "localhost:50051",
+		dialTimeout: 10 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	if c.target == "" {
+		return nil, errors.New("target address is required")
+	}
+
+	dialOpts := c.dialOptions
+
+	// set insecure credentials if none provided
+	dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	// Set connect parameters with the dial timeout
+	connectParams := grpc.ConnectParams{
+		Backoff:           backoff.DefaultConfig,
+		MinConnectTimeout: c.dialTimeout,
+	}
+	dialOpts = append(dialOpts, grpc.WithConnectParams(connectParams))
+
+	conn, err := grpc.NewClient(c.target, dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	return &HealthChecker{client: client, conn: conn}, nil
+}

--- a/grpc/server/server.go
+++ b/grpc/server/server.go
@@ -112,8 +112,7 @@ func WithGRPCServer(
 // WithGateway adds a dedicated HTTP server for the gRPC-REST gateway
 // It creates an HTTP server with a mux configured solely for the gateway.
 func WithGateway(name, port string, httpOpts []HTTPConfigOption, gatewayOpts ...gateway.Option) Option {
-	mux := http.NewServeMux()
-	_, err := gateway.NewGateway(append([]gateway.Option{gateway.WithMux(mux)}, gatewayOpts...)...)
+	mux, err := gateway.NewGateway(gatewayOpts...)
 	if err != nil {
 		return func(_ *Server) error {
 			return fmt.Errorf("failed to create gateway: %w", err)


### PR DESCRIPTION
* Added grpc health client that can be used globally.
* Removed custom gateway health client,  configured default one instead:

```
healthClient, err := h.NewHealthChecker(h.WithTarget("localhost:" + cfg.Server.GRPC))
	if err != nil {
		logger.Fatal("failed to create health checker", zap.Error(err))
	}
	defer healthClient.Close()
		
...

gateway.WithGatewayOptions(runtime.WithHealthEndpointAt(healthClient.Client(), constants.HealthPath)),
```